### PR TITLE
fix(auth-api): fix version issue

### DIFF
--- a/services/auth-api/scripts/start
+++ b/services/auth-api/scripts/start
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+export NODE_ENV=production
+
 node dist/main

--- a/services/auth-api/src/core/swagger/openapi.ts
+++ b/services/auth-api/src/core/swagger/openapi.ts
@@ -4,7 +4,7 @@ import { DocumentBuilder, OpenAPIObject, SwaggerModule } from "@nestjs/swagger";
 import { Logger } from "../logging/logger.service";
 
 const APP_NAME = "Auth";
-const APP_VERSION = process.env.npm_package_version;
+const APP_VERSION = "latest";
 
 export function createOpenApiDocument(app: INestApplication): OpenAPIObject {
   const logger = new Logger("NestJS");

--- a/services/auth-api/src/main.ts
+++ b/services/auth-api/src/main.ts
@@ -42,4 +42,5 @@ async function bootstrap() {
 
   await app.listen(PORT, "0.0.0.0");
 }
+
 bootstrap();


### PR DESCRIPTION
Service failed due version not being able to be read. This version is not used for anything so we might as well call it "latest" as we already do the in the API service