### PR TITLE
refactor(api): avoid double import

### DIFF
--- a/services/api/src/features/blogs/blogs.module.ts
+++ b/services/api/src/features/blogs/blogs.module.ts
@@ -1,6 +1,5 @@
 import { Module } from "@nestjs/common";
 import { CqrsModule } from "@nestjs/cqrs";
-import { ScheduleModule } from "@nestjs/schedule";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 import { AuthorizationModule } from "src/core/authorization/authorization.module";
@@ -56,7 +55,6 @@ import { BlogPost } from "./infrastructure/entities/blog-post.entity";
       BlogPostReaction,
       Profile,
     ]),
-    ScheduleModule.forRoot(),
   ],
   controllers: [
     BlogsController,


### PR DESCRIPTION
Module is already imported as a root module in `app.module.ts`