### PR TITLE
chore(repo): avoid exposing db port

### DIFF
--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -115,8 +115,6 @@ services:
     environment:
       POSTGRES_PASSWORD: "$POSTGRES_PASSWORD"
       POSTGRES_USERNAME: "$POSTGRES_USERNAME"
-    ports:
-      - "5432:5432"
     volumes:
       - "$PWD/config/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql"
       - ".data/postgres:/var/lib/postgresql/data:rw"


### PR DESCRIPTION
Database port should not be exposed as it is not used for any functionality outside the internal services and poses a security threat