### PR TITLE
chore(repo): avoid using basic auth on minio dashboard

### DIFF
--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -167,7 +167,6 @@ services:
       - "traefik.http.routers.minio.entrypoints=web"
       - "traefik.http.routers.minio.rule=Host(`minio.console.$DOMAIN`)"
       - "traefik.http.routers.minio.service=minio"
-      - "traefik.http.routers.minio.middlewares=basicauth"
       - "traefik.http.services.minio.loadbalancer.server.port=9001"
 
       - "traefik.http.routers.s3.entrypoints=web"


### PR DESCRIPTION
The minio console already has its own login so adding the basicauth here is redundant. It also doesn't work and causes an infinite request loop when trying to login