### PR TITLE
chore(auth-ui): fix nginx redirect

### DIFF
--- a/services/auth-ui/nginx.conf
+++ b/services/auth-ui/nginx.conf
@@ -7,6 +7,10 @@ server {
 	}
 
 	# Explicitly handle /login path for client-side routing and assets
+	location = /login {
+		try_files $uri /login/index.html;
+	}
+
 	location /login/ {
 		try_files $uri $uri/ /login/index.html;
 	}


### PR DESCRIPTION
The main application will make a request to the auth-api service to see if the request is authenticated. If not, it is forwarded to the auth-ui which normally would check the refresh token and issue a new token. However, after migrating to nginx it seems the refresh token is no longer checked (it could also be to the recent shift of to custom components in Supertokens). One possible offender is this redirect.  The main application redirects to `/login?redirectPath=...` where the last argument is that path that should be redirected to after successful authentication, however, it seems this is lost