### PR TITLE
fix(web-ui): use external link when loading logout

### DIFF
--- a/services/web-ui/src/core/profiles/pages/CurrentProfilePage/components/CurrentProfileDetails/CurrentProfileDetails.tsx
+++ b/services/web-ui/src/core/profiles/pages/CurrentProfilePage/components/CurrentProfileDetails/CurrentProfileDetails.tsx
@@ -50,6 +50,25 @@ const NavItem = ({
   </ListItem>
 );
 
+const ExternalNavItem = ({
+  Icon,
+  text,
+  to,
+}: {
+  Icon: FC;
+  text: string | null;
+  to: string;
+}) => (
+  <ListItem disablePadding>
+    <ListItemButton component="a" href={to}>
+      <ListItemIcon>
+        <Icon />
+      </ListItemIcon>
+      <ListItemText primary={text} />
+    </ListItemButton>
+  </ListItem>
+);
+
 interface CurrentProfileDetailsProps {
   profile: ProfileDetails;
 }
@@ -127,7 +146,7 @@ export function CurrentProfileDetails({
           text={t("links.settings")}
           to="/profile/settings"
         />
-        <NavItem Icon={Logout} text={t("links.log-out")} to="/logout" />
+        <ExternalNavItem Icon={Logout} text={t("links.log-out")} to="/logout" />
       </List>
 
       <form style={{ display: "none" }}>


### PR DESCRIPTION
The `/logout` route is handled by a different SPA meaning we cannot use the internal nav by react router