### PR TITLE
fix(auth-ui): avoid redirecting to main app when verifying email

### DIFF
--- a/services/auth-ui/src/Router.tsx
+++ b/services/auth-ui/src/Router.tsx
@@ -10,6 +10,12 @@ import { ResetPassword } from "./pages/ResetPassword";
 import { SignUp } from "./pages/SignUp";
 import { VerifyEmail } from "./pages/VerifyEmail";
 
+const errorElement = (
+  <Nav>
+    <NotFound />
+  </Nav>
+);
+
 const router = createBrowserRouter([
   {
     path: "/login",
@@ -20,11 +26,7 @@ const router = createBrowserRouter([
         </Nav>
       </AuthGuard>
     ),
-    errorElement: (
-      <Nav>
-        <NotFound />
-      </Nav>
-    ),
+    errorElement,
     children: [
       {
         path: "reset-password",
@@ -35,12 +37,23 @@ const router = createBrowserRouter([
         element: <SignUp />,
       },
       {
-        path: "verify-email",
-        element: <VerifyEmail />,
-      },
-      {
         path: "",
         element: <LogIn />,
+      },
+    ],
+  },
+  {
+    path: "/login",
+    element: (
+      <Nav>
+        <Outlet />
+      </Nav>
+    ),
+    errorElement,
+    children: [
+      {
+        path: "verify-email",
+        element: <VerifyEmail />,
       },
     ],
   },


### PR DESCRIPTION
The `AuthGuard` component will redirect the user to the main application if logged in, however, when verifying email, the user will be logged in but should not be redirected. 