### PR TITLE
fix(auth-ui): avoid redirecting to main app on email verify page

### DIFF
--- a/services/auth-ui/src/Router.tsx
+++ b/services/auth-ui/src/Router.tsx
@@ -35,14 +35,18 @@ const router = createBrowserRouter([
         element: <SignUp />,
       },
       {
-        path: "verify-email",
-        element: <VerifyEmail />,
-      },
-      {
         path: "",
         element: <LogIn />,
       },
     ],
+  },
+  {
+    path: "/login/verify-email",
+    element: (
+      <Nav>
+        <VerifyEmail />
+      </Nav>
+    ),
   },
   {
     path: "/login/logout",


### PR DESCRIPTION


The AuthGuard component will redirect the user to the main application if logged in, however, when verifying email, the user will be logged in but should not be redirected.
