### PR TITLE
chore(repo): expose db port in dev

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -50,6 +50,8 @@ services:
     extends:
       file: "./docker-compose.shared.yaml"
       service: "db"
+    ports:
+      - 5432:5432
 
   minio:
     extends:


### PR DESCRIPTION
The db port is needed in dev in order to generate typeorm migrations from the cli