### PR TITLE
refactor(web-ui): move nav back link into nav component

### DIFF
--- a/services/web-ui/src/components/nav/components/NavDesktop/NavDesktop.tsx
+++ b/services/web-ui/src/components/nav/components/NavDesktop/NavDesktop.tsx
@@ -1,6 +1,16 @@
 import { FC } from "react";
+import { Link as ReactRouterLink } from "react-router";
 
-import { Box, Container, List, Stack, Toolbar } from "@mui/material";
+import { ArrowBack } from "@mui/icons-material";
+import {
+  Box,
+  Container,
+  IconButton,
+  List,
+  Stack,
+  Toolbar,
+  Typography,
+} from "@mui/material";
 
 import {
   DRAWER_WIDTH,
@@ -13,8 +23,35 @@ import { AppBar } from "../AppBar";
 import { NavLinkListItem } from "./NavLinkListItem";
 import { NavProfile } from "./NavProfile";
 
-export const NavDesktop: FC<NavProps> = ({ appBarContent, children }) => {
+export const NavDesktop: FC<NavProps> = ({
+  appBarContent,
+  children,
+  navBackTo,
+  title,
+}) => {
   const desktopNav = useDesktopNavItems();
+
+  if (navBackTo) {
+    appBarContent = (
+      <>
+        <IconButton
+          component={ReactRouterLink}
+          sx={{
+            mr: 2,
+          }}
+          to={navBackTo}
+        >
+          <ArrowBack />
+        </IconButton>
+
+        {title && (
+          <Typography color="textPrimary" sx={{ pl: 3 }} variant="h5">
+            {title}
+          </Typography>
+        )}
+      </>
+    );
+  }
 
   return (
     <Box sx={{ height: "100vh", minHeight: "100%" }}>

--- a/services/web-ui/src/components/nav/components/NavMobile/NavMobile.tsx
+++ b/services/web-ui/src/components/nav/components/NavMobile/NavMobile.tsx
@@ -1,12 +1,41 @@
 import { FC } from "react";
+import { Link as ReactRouterLink } from "react-router";
 
-import { Box, Container, Toolbar } from "@mui/material";
+import { ArrowBack } from "@mui/icons-material";
+import { Box, Container, IconButton, Toolbar, Typography } from "@mui/material";
 
 import { NavProps } from "../../types";
 import { AppBar } from "../AppBar";
 import { BottomNavigation } from "../BottomNavigation";
 
-export const NavMobile: FC<NavProps> = ({ appBarContent, children }) => {
+export const NavMobile: FC<NavProps> = ({
+  appBarContent,
+  children,
+  navBackTo,
+  title,
+}) => {
+  if (navBackTo) {
+    appBarContent = (
+      <>
+        <IconButton
+          component={ReactRouterLink}
+          sx={{
+            mr: 2,
+          }}
+          to={navBackTo}
+        >
+          <ArrowBack />
+        </IconButton>
+
+        {title && (
+          <Typography color="textPrimary" sx={{ pl: 3 }} variant="h5">
+            {title}
+          </Typography>
+        )}
+      </>
+    );
+  }
+
   return (
     <Box sx={{ height: "100vh", minHeight: "100%" }}>
       <AppBar appBarContent={appBarContent} />

--- a/services/web-ui/src/components/nav/types.ts
+++ b/services/web-ui/src/components/nav/types.ts
@@ -24,4 +24,6 @@ export interface MobileNav {
 export interface NavProps {
   appBarContent?: ReactNode;
   children: ReactNode;
+  navBackTo?: string;
+  title?: string;
 }

--- a/services/web-ui/src/core/organizations/pages/CreateOrganizationPage/CreateOrganizationPage.container.tsx
+++ b/services/web-ui/src/core/organizations/pages/CreateOrganizationPage/CreateOrganizationPage.container.tsx
@@ -1,8 +1,7 @@
 import { ReactElement, SyntheticEvent } from "react";
-import { Link as ReactRouterLink, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { CreateOrganizationCommand } from "src/api";
 import { organizationsApi } from "src/apis";
@@ -61,26 +60,8 @@ export function CreateOrganizationPageContainer(): ReactElement {
     });
   }
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-
-        <Typography color="textPrimary" sx={{ pl: 3 }} variant="h5">
-          {t("header")}
-        </Typography>
-      </IconButton>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title={t("header")}>
       <Box sx={{ px: 2, pt: 2 }}>
         <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
           {t("description")}

--- a/services/web-ui/src/core/organizations/pages/CurrentOrganizationPage/CurrentOrganizationPage.nav.tsx
+++ b/services/web-ui/src/core/organizations/pages/CurrentOrganizationPage/CurrentOrganizationPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 
@@ -13,22 +11,8 @@ interface CurrentOrganizationPageNavProps {
 export function CurrentOrganizationPageNav({
   children,
 }: CurrentOrganizationPageNavProps): ReactElement {
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-      </IconButton>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title="">
       <Box sx={{ px: 2, pt: 2 }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/core/organizations/pages/OrganizationJournalPage/OrganizationJournalPage.nav.tsx
+++ b/services/web-ui/src/core/organizations/pages/OrganizationJournalPage/OrganizationJournalPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, Grid, IconButton, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { DatePicker } from "src/components/ui/DatePicker";
@@ -26,24 +24,8 @@ export function OrganizationJournalPageNav({
 }: OrganizationJournalPageNavProps): ReactElement {
   const { t } = useTranslation("journal");
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title={t("header")}>
       <Box sx={{ pt: 1, px: 3 }}>
         <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
           {t("description")}

--- a/services/web-ui/src/core/organizations/pages/OrganizationListPage/OrganizationListPage.nav.tsx
+++ b/services/web-ui/src/core/organizations/pages/OrganizationListPage/OrganizationListPage.nav.tsx
@@ -1,8 +1,7 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { Add, ArrowBack } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Add } from "@mui/icons-material";
+import { Box, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { Fab } from "src/components/ui/Fab";
@@ -17,24 +16,8 @@ export function OrganizationListPageNav({
 }: OrganizationListPageNavProps): ReactElement {
   const { t } = useTranslation("organization-list");
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title={t("header")}>
       <Box sx={{ pt: 2, px: 3 }}>
         <Typography color="textSecondary" gutterBottom>
           {t("description")}

--- a/services/web-ui/src/core/profiles/pages/ProfileJournalPage/ProfileJournalPage.nav.tsx
+++ b/services/web-ui/src/core/profiles/pages/ProfileJournalPage/ProfileJournalPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, Grid, IconButton, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { DatePicker } from "src/components/ui/DatePicker";
@@ -26,24 +24,8 @@ export function ProfileJournalPageNav({
 }: ProfileJournalPageNavProps): ReactElement {
   const { t } = useTranslation("journal");
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title={t("header")}>
       <Box sx={{ pt: 1, px: 3 }}>
         <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
           {t("description")}

--- a/services/web-ui/src/core/profiles/pages/ProfilePage/ProfilePage.nav.tsx
+++ b/services/web-ui/src/core/profiles/pages/ProfilePage/ProfilePage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 
@@ -13,16 +11,8 @@ interface ProfilePageNavProps {
 export function ProfilePageNav({
   children,
 }: ProfilePageNavProps): ReactElement {
-  const appBarContent = (
-    <>
-      <IconButton component={ReactRouterLink} to="/">
-        <ArrowBack />
-      </IconButton>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/" title="">
       <Box sx={{ pt: 4 }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/features/blogs/pages/BlogPostPage/BlogPostPage.nav.tsx
+++ b/services/web-ui/src/features/blogs/pages/BlogPostPage/BlogPostPage.nav.tsx
@@ -1,8 +1,4 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
-
-import { ArrowBack } from "@mui/icons-material";
-import { IconButton } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 
@@ -13,19 +9,5 @@ interface BlogPostPageNavProps {
 export function BlogPostPageNav({
   children,
 }: BlogPostPageNavProps): ReactElement {
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/"
-      >
-        <ArrowBack />
-      </IconButton>
-    </>
-  );
-
-  return <Nav appBarContent={appBarContent}>{children}</Nav>;
+  return <Nav navBackTo="/">{children}</Nav>;
 }

--- a/services/web-ui/src/features/blogs/pages/CreateBlogPostPage/CreateBlogPostPage.nav.tsx
+++ b/services/web-ui/src/features/blogs/pages/CreateBlogPostPage/CreateBlogPostPage.nav.tsx
@@ -1,8 +1,4 @@
 import { ReactElement, ReactNode } from "react";
-import { Link } from "react-router";
-
-import { ArrowBack } from "@mui/icons-material";
-import { IconButton, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
@@ -16,21 +12,9 @@ export function CreateBlogPostPageNav({
 }: CreateBlogPostPageNavProps): ReactElement {
   const { t } = useTranslation("blog-creation");
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={Link}
-        sx={{
-          mr: 2,
-        }}
-        to="/"
-      >
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
+  return (
+    <Nav navBackTo="/" title={t("header")}>
+      {children}
+    </Nav>
   );
-
-  return <Nav appBarContent={appBarContent}>{children}</Nav>;
 }

--- a/services/web-ui/src/features/chat/pages/ChatPage/ChatPage.nav.tsx
+++ b/services/web-ui/src/features/chat/pages/ChatPage/ChatPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 
@@ -11,20 +9,8 @@ interface ChatPageNavProps {
 }
 
 export function ChatPageNav({ children }: ChatPageNavProps): ReactElement {
-  const appBarContent = (
-    <IconButton
-      component={ReactRouterLink}
-      sx={{
-        mr: 2,
-      }}
-      to="/chat"
-    >
-      <ArrowBack />
-    </IconButton>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/chat">
       <Box
         sx={{
           display: "flex",

--- a/services/web-ui/src/features/chat/pages/CreateChatPage/CreateChatPage.nav.tsx
+++ b/services/web-ui/src/features/chat/pages/CreateChatPage/CreateChatPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
@@ -16,20 +14,8 @@ export function CreateChatPageNav({
 }: CreateChatPageNavProps): ReactElement {
   const { t } = useTranslation("chat-create");
 
-  const appBarContent = (
-    <>
-      <IconButton component={ReactRouterLink} to="/chat">
-        <ArrowBack />
-
-        <Typography color="textPrimary" sx={{ pl: 3 }} variant="h5">
-          {t("header")}
-        </Typography>
-      </IconButton>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/chat" title={t("header")}>
       <Box sx={{ px: 3, pt: 1 }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/features/settings/pages/AppearancePage/AppearancePage.nav.tsx
+++ b/services/web-ui/src/features/settings/pages/AppearancePage/AppearancePage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
@@ -16,24 +14,8 @@ export function AppearancePageNav({
 }: AppearancePageNavProps): ReactElement {
   const { t } = useTranslation("settings");
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title={t("header")}>
       <Box sx={{ p: 3 }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/features/settings/pages/SettingsPage/SettingsPage.nav.tsx
+++ b/services/web-ui/src/features/settings/pages/SettingsPage/SettingsPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link as ReactRouterLink } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
@@ -16,24 +14,8 @@ export function SettingsPageNav({
 }: SettingsPageNavProps): ReactElement {
   const { t } = useTranslation("settings");
 
-  const appBarContent = (
-    <>
-      <IconButton
-        component={ReactRouterLink}
-        sx={{
-          mr: 2,
-        }}
-        to="/profile"
-      >
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/profile" title={t("header")}>
       <Box sx={{ p: 3 }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/features/time-series/pages/CreateTimeSeriesPage/CreateTimeSeriesPage.nav.tsx
+++ b/services/web-ui/src/features/time-series/pages/CreateTimeSeriesPage/CreateTimeSeriesPage.nav.tsx
@@ -1,8 +1,4 @@
 import { ReactElement, ReactNode } from "react";
-import { Link } from "react-router";
-
-import { ArrowBack } from "@mui/icons-material";
-import { IconButton, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
@@ -16,15 +12,9 @@ export function CreateTimeSeriesPageNav({
 }: CreateTimeSeriesPageNavProps): ReactElement {
   const { t } = useTranslation("timeseries-creation");
 
-  const appBarContent = (
-    <>
-      <IconButton component={Link} sx={{ mr: 2 }} to="/time-series">
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
+  return (
+    <Nav navBackTo="/time-series" title={t("header")}>
+      {children}
+    </Nav>
   );
-
-  return <Nav appBarContent={appBarContent}>{children}</Nav>;
 }

--- a/services/web-ui/src/features/time-series/pages/TimeSeriesPage/TimeSeriesPage.nav.tsx
+++ b/services/web-ui/src/features/time-series/pages/TimeSeriesPage/TimeSeriesPage.nav.tsx
@@ -1,8 +1,6 @@
 import { ReactElement, ReactNode } from "react";
-import { Link } from "react-router";
 
-import { ArrowBack } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
@@ -16,18 +14,8 @@ export function TimeSeriesPageNav({
 }: TimeSeriesPageNavProps): ReactElement {
   const { t } = useTranslation("time-series");
 
-  const appBarContent = (
-    <>
-      <IconButton component={Link} sx={{ mr: 2 }} to="/time-series">
-        <ArrowBack />
-      </IconButton>
-
-      <Typography variant="h5">{t("header")}</Typography>
-    </>
-  );
-
   return (
-    <Nav appBarContent={appBarContent}>
+    <Nav navBackTo="/time-series" title={t("header")}>
       <Box sx={{ p: 2 }}> {children}</Box>
     </Nav>
   );


### PR DESCRIPTION
Instead of having the back navigation defined as a custom element in each nav, we now have custom props for it