### PR TITLE
refactor(web-ui): move padding into nav

### DIFF
--- a/services/web-ui/src/components/nav/components/NavDesktop/NavDesktop.tsx
+++ b/services/web-ui/src/components/nav/components/NavDesktop/NavDesktop.tsx
@@ -27,6 +27,7 @@ export const NavDesktop: FC<NavProps> = ({
   appBarContent,
   children,
   navBackTo,
+  padding,
   title,
 }) => {
   const desktopNav = useDesktopNavItems();
@@ -73,18 +74,23 @@ export const NavDesktop: FC<NavProps> = ({
           maxWidth="md"
           sx={{
             flexGrow: 1,
+            padding: padding === "normal" ? 2 : undefined,
           }}
         >
           {(navBackTo || title) && (
-            <Box sx={{ display: "flex", alignItems: "center", p: 2 }}>
+            <Box sx={{ display: "flex", alignItems: "center" }}>
               {navBackTo && (
-                <IconButton component={ReactRouterLink} to={navBackTo}>
+                <IconButton
+                  component={ReactRouterLink}
+                  to={navBackTo}
+                  sx={{ mr: 1 }}
+                >
                   <ArrowBack />
                 </IconButton>
               )}
 
               {title && (
-                <Typography color="textPrimary" sx={{ pl: 1 }} variant="h5">
+                <Typography color="textPrimary" variant="h5">
                   {title}
                 </Typography>
               )}

--- a/services/web-ui/src/components/nav/components/NavMobile/NavMobile.tsx
+++ b/services/web-ui/src/components/nav/components/NavMobile/NavMobile.tsx
@@ -13,6 +13,7 @@ export const NavMobile: FC<NavProps> = ({
   appBarContent,
   children,
   navBackTo,
+  padding,
   title,
 }) => {
   if (navBackTo || title) {
@@ -54,6 +55,7 @@ export const NavMobile: FC<NavProps> = ({
           maxWidth="md"
           sx={{
             flexGrow: 1,
+            padding: padding === "normal" ? 2 : undefined,
           }}
         >
           {children}

--- a/services/web-ui/src/components/nav/types.ts
+++ b/services/web-ui/src/components/nav/types.ts
@@ -25,5 +25,6 @@ export interface NavProps {
   appBarContent?: ReactNode;
   children: ReactNode;
   navBackTo?: string;
+  padding: "none" | "normal";
   title?: string;
 }

--- a/services/web-ui/src/core/organizations/pages/CreateOrganizationPage/CreateOrganizationPage.container.tsx
+++ b/services/web-ui/src/core/organizations/pages/CreateOrganizationPage/CreateOrganizationPage.container.tsx
@@ -61,40 +61,38 @@ export function CreateOrganizationPageContainer(): ReactElement {
   }
 
   return (
-    <Nav navBackTo="/profile" title={t("header")}>
-      <Box sx={{ px: 2, pt: 2 }}>
-        <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
-          {t("description")}
-        </Typography>
+    <Nav navBackTo="/profile" padding="normal" title={t("header")}>
+      <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
+        {t("description")}
+      </Typography>
 
-        <form onSubmit={handleSubmit}>
-          <TextField
-            error={form.state.name.error || ""}
-            fullWidth
-            label={t("fields.name.label")}
-            onBlur={() => form.validate()}
-            onChange={(name) => form.setValue({ name })}
-            required
-            sx={{ marginBottom: 2 }}
-            value={form.state.name.value}
-          />
+      <form onSubmit={handleSubmit}>
+        <TextField
+          error={form.state.name.error || ""}
+          fullWidth
+          label={t("fields.name.label")}
+          onBlur={() => form.validate()}
+          onChange={(name) => form.setValue({ name })}
+          required
+          sx={{ marginBottom: 2 }}
+          value={form.state.name.value}
+        />
 
-          <Box sx={{ gap: 1, display: "flex", justifyContent: "flex-end" }}>
-            <Button onClick={handleCancel} variant="outlined">
-              {t("actions.cancel.button")}
-            </Button>
+        <Box sx={{ gap: 1, display: "flex", justifyContent: "flex-end" }}>
+          <Button onClick={handleCancel} variant="outlined">
+            {t("actions.cancel.button")}
+          </Button>
 
-            <Button
-              disabled={!form.isValid}
-              loading={mutation.isPending}
-              type="submit"
-              variant="contained"
-            >
-              {t("actions.submit.button")}
-            </Button>
-          </Box>
-        </form>
-      </Box>
+          <Button
+            disabled={!form.isValid}
+            loading={mutation.isPending}
+            type="submit"
+            variant="contained"
+          >
+            {t("actions.submit.button")}
+          </Button>
+        </Box>
+      </form>
     </Nav>
   );
 }

--- a/services/web-ui/src/core/organizations/pages/CurrentOrganizationPage/CurrentOrganizationPage.nav.tsx
+++ b/services/web-ui/src/core/organizations/pages/CurrentOrganizationPage/CurrentOrganizationPage.nav.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box } from "@mui/material";
-
 import { Nav } from "src/components/nav";
 
 interface CurrentOrganizationPageNavProps {
@@ -12,8 +10,8 @@ export function CurrentOrganizationPageNav({
   children,
 }: CurrentOrganizationPageNavProps): ReactElement {
   return (
-    <Nav navBackTo="/profile" title="">
-      <Box sx={{ px: 2, pt: 2 }}>{children}</Box>
+    <Nav navBackTo="/profile" padding="normal" title="">
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/core/organizations/pages/OrganizationJournalPage/OrganizationJournalPage.nav.tsx
+++ b/services/web-ui/src/core/organizations/pages/OrganizationJournalPage/OrganizationJournalPage.nav.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box, Grid, Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { DatePicker } from "src/components/ui/DatePicker";
@@ -25,34 +25,32 @@ export function OrganizationJournalPageNav({
   const { t } = useTranslation("journal");
 
   return (
-    <Nav navBackTo="/profile" title={t("header")}>
-      <Box sx={{ pt: 1, px: 3 }}>
-        <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
-          {t("description")}
-        </Typography>
+    <Nav navBackTo="/profile" padding="normal" title={t("header")}>
+      <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
+        {t("description")}
+      </Typography>
 
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 6 }}>
-            <DatePicker
-              fullWidth
-              label="From"
-              onChange={(from) => onDateChange({ ...values, from })}
-              value={values.from}
-            />
-          </Grid>
-
-          <Grid size={{ xs: 6 }}>
-            <DatePicker
-              fullWidth
-              label="To"
-              onChange={(to) => onDateChange({ ...values, to })}
-              value={values.to}
-            />
-          </Grid>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 6 }}>
+          <DatePicker
+            fullWidth
+            label="From"
+            onChange={(from) => onDateChange({ ...values, from })}
+            value={values.from}
+          />
         </Grid>
 
-        {children}
-      </Box>
+        <Grid size={{ xs: 6 }}>
+          <DatePicker
+            fullWidth
+            label="To"
+            onChange={(to) => onDateChange({ ...values, to })}
+            value={values.to}
+          />
+        </Grid>
+      </Grid>
+
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/core/organizations/pages/OrganizationListPage/OrganizationListPage.nav.tsx
+++ b/services/web-ui/src/core/organizations/pages/OrganizationListPage/OrganizationListPage.nav.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode } from "react";
 
 import { Add } from "@mui/icons-material";
-import { Box, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { Fab } from "src/components/ui/Fab";
@@ -17,18 +17,16 @@ export function OrganizationListPageNav({
   const { t } = useTranslation("organization-list");
 
   return (
-    <Nav navBackTo="/profile" title={t("header")}>
-      <Box sx={{ pt: 2, px: 3 }}>
-        <Typography color="textSecondary" gutterBottom>
-          {t("description")}
-        </Typography>
+    <Nav navBackTo="/profile" padding="normal" title={t("header")}>
+      <Typography color="textSecondary" gutterBottom>
+        {t("description")}
+      </Typography>
 
-        <Fab to="/group/create">
-          <Add />
-        </Fab>
+      <Fab to="/group/create">
+        <Add />
+      </Fab>
 
-        {children}
-      </Box>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/core/profiles/pages/CurrentProfilePage/CurrentProfilePage.nav.tsx
+++ b/services/web-ui/src/core/profiles/pages/CurrentProfilePage/CurrentProfilePage.nav.tsx
@@ -12,7 +12,7 @@ export function CurrentProfilePageNav({
   children,
 }: CurrentProfilePageNavProps): ReactElement {
   return (
-    <Nav>
+    <Nav padding="none">
       <Box sx={{ pt: 6, px: 3, mb: 3, height: "100%" }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/core/profiles/pages/ProfileJournalPage/ProfileJournalPage.nav.tsx
+++ b/services/web-ui/src/core/profiles/pages/ProfileJournalPage/ProfileJournalPage.nav.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box, Grid, Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { DatePicker } from "src/components/ui/DatePicker";
@@ -25,34 +25,32 @@ export function ProfileJournalPageNav({
   const { t } = useTranslation("journal");
 
   return (
-    <Nav navBackTo="/profile" title={t("header")}>
-      <Box sx={{ pt: 1, px: 3 }}>
-        <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
-          {t("description")}
-        </Typography>
+    <Nav navBackTo="/profile" padding="normal" title={t("header")}>
+      <Typography color="textSecondary" sx={{ paddingBottom: 3 }}>
+        {t("description")}
+      </Typography>
 
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 6 }}>
-            <DatePicker
-              fullWidth
-              label="From"
-              onChange={(from) => onDateChange({ ...values, from })}
-              value={values.from}
-            />
-          </Grid>
-
-          <Grid size={{ xs: 6 }}>
-            <DatePicker
-              fullWidth
-              label="To"
-              onChange={(to) => onDateChange({ ...values, to })}
-              value={values.to}
-            />
-          </Grid>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 6 }}>
+          <DatePicker
+            fullWidth
+            label="From"
+            onChange={(from) => onDateChange({ ...values, from })}
+            value={values.from}
+          />
         </Grid>
 
-        {children}
-      </Box>
+        <Grid size={{ xs: 6 }}>
+          <DatePicker
+            fullWidth
+            label="To"
+            onChange={(to) => onDateChange({ ...values, to })}
+            value={values.to}
+          />
+        </Grid>
+      </Grid>
+
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/core/profiles/pages/ProfilePage/ProfilePage.nav.tsx
+++ b/services/web-ui/src/core/profiles/pages/ProfilePage/ProfilePage.nav.tsx
@@ -12,7 +12,7 @@ export function ProfilePageNav({
   children,
 }: ProfilePageNavProps): ReactElement {
   return (
-    <Nav navBackTo="/" title="">
+    <Nav navBackTo="/" padding="none" title="">
       <Box sx={{ pt: 4 }}>{children}</Box>
     </Nav>
   );

--- a/services/web-ui/src/features/blogs/pages/BlogPhotoListPage/BlogPhotoListPage.nav.tsx
+++ b/services/web-ui/src/features/blogs/pages/BlogPhotoListPage/BlogPhotoListPage.nav.tsx
@@ -2,10 +2,9 @@ import { ReactElement, ReactNode } from "react";
 import { Link } from "react-router";
 
 import { ViewDayOutlined } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, IconButton } from "@mui/material";
 
-import { CurrentOrganizationAvatar, Nav } from "src/components/nav";
-import { config } from "src/config";
+import { CurrentOrganizationAvatar, Logo, Nav } from "src/components/nav";
 
 interface BlogPhotoListPageNavProps {
   children: ReactNode;
@@ -18,21 +17,7 @@ export function BlogPhotoListPageNav({
     <>
       <CurrentOrganizationAvatar />
 
-      <Typography
-        sx={(theme) => ({
-          background: `linear-gradient(to right, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
-          backgroundClip: "text",
-          color: "transparent",
-          fontFamily: "sans-serif",
-          fontWeight: 600,
-          ml: 3,
-          textShadow: `1px 1px 1px ${theme.palette.text.primary}`,
-          userSelect: "none",
-        })}
-        variant="h5"
-      >
-        {config.APP.NAME}
-      </Typography>
+      <Logo />
 
       <Box sx={{ flexGrow: 1 }} />
 
@@ -42,5 +27,9 @@ export function BlogPhotoListPageNav({
     </>
   );
 
-  return <Nav appBarContent={appBarContent}>{children}</Nav>;
+  return (
+    <Nav appBarContent={appBarContent} padding="none">
+      {children}
+    </Nav>
+  );
 }

--- a/services/web-ui/src/features/blogs/pages/BlogPostListPage/BlogPostListPage.nav.tsx
+++ b/services/web-ui/src/features/blogs/pages/BlogPostListPage/BlogPostListPage.nav.tsx
@@ -27,5 +27,9 @@ export function BlogPostListPageNav({
     </>
   );
 
-  return <Nav appBarContent={appBarContent}>{children}</Nav>;
+  return (
+    <Nav appBarContent={appBarContent} padding="none">
+      {children}
+    </Nav>
+  );
 }

--- a/services/web-ui/src/features/blogs/pages/BlogPostPage/BlogPostPage.nav.tsx
+++ b/services/web-ui/src/features/blogs/pages/BlogPostPage/BlogPostPage.nav.tsx
@@ -9,5 +9,9 @@ interface BlogPostPageNavProps {
 export function BlogPostPageNav({
   children,
 }: BlogPostPageNavProps): ReactElement {
-  return <Nav navBackTo="/">{children}</Nav>;
+  return (
+    <Nav navBackTo="/" padding="none">
+      {children}
+    </Nav>
+  );
 }

--- a/services/web-ui/src/features/blogs/pages/CreateBlogPostPage/CreateBlogPostPage.container.tsx
+++ b/services/web-ui/src/features/blogs/pages/CreateBlogPostPage/CreateBlogPostPage.container.tsx
@@ -1,8 +1,6 @@
 import { ReactElement } from "react";
 import { useNavigate } from "react-router";
 
-import { Box } from "@mui/material";
-
 import { useTranslation } from "src/core/i18n";
 import { useSnackbar } from "src/core/snackbar";
 
@@ -21,9 +19,7 @@ export function CreateBlogPostPageContainer(): ReactElement {
 
   return (
     <CreateBlogPostPageNav>
-      <Box sx={{ py: 2, px: 2 }}>
-        <CreateBlogPostPageComponent onAfterSubmit={handleSubmit} />
-      </Box>
+      <CreateBlogPostPageComponent onAfterSubmit={handleSubmit} />
     </CreateBlogPostPageNav>
   );
 }

--- a/services/web-ui/src/features/blogs/pages/CreateBlogPostPage/CreateBlogPostPage.nav.tsx
+++ b/services/web-ui/src/features/blogs/pages/CreateBlogPostPage/CreateBlogPostPage.nav.tsx
@@ -13,7 +13,7 @@ export function CreateBlogPostPageNav({
   const { t } = useTranslation("blog-creation");
 
   return (
-    <Nav navBackTo="/" title={t("header")}>
+    <Nav navBackTo="/" padding="normal" title={t("header")}>
       {children}
     </Nav>
   );

--- a/services/web-ui/src/features/chat/pages/ChatListPage/ChatListPage.nav.tsx
+++ b/services/web-ui/src/features/chat/pages/ChatListPage/ChatListPage.nav.tsx
@@ -1,7 +1,6 @@
 import { ReactElement, ReactNode } from "react";
 
 import { Add } from "@mui/icons-material";
-import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { Fab } from "src/components/ui/Fab";
@@ -17,14 +16,12 @@ export function ChatListPageNav({
   const { t } = useTranslation("connections");
 
   return (
-    <Nav title={t("header")}>
-      <Box sx={{ p: 2 }}>
-        <Fab to="/chat/create">
-          <Add />
-        </Fab>
+    <Nav padding="normal" title={t("header")}>
+      <Fab to="/chat/create">
+        <Add />
+      </Fab>
 
-        {children}
-      </Box>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/features/chat/pages/ChatPage/ChatPage.nav.tsx
+++ b/services/web-ui/src/features/chat/pages/ChatPage/ChatPage.nav.tsx
@@ -10,7 +10,7 @@ interface ChatPageNavProps {
 
 export function ChatPageNav({ children }: ChatPageNavProps): ReactElement {
   return (
-    <Nav navBackTo="/chat">
+    <Nav navBackTo="/chat" padding="none">
       <Box
         sx={{
           display: "flex",

--- a/services/web-ui/src/features/chat/pages/CreateChatPage/CreateChatPage.nav.tsx
+++ b/services/web-ui/src/features/chat/pages/CreateChatPage/CreateChatPage.nav.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box } from "@mui/material";
-
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
 
@@ -15,8 +13,8 @@ export function CreateChatPageNav({
   const { t } = useTranslation("chat-create");
 
   return (
-    <Nav navBackTo="/chat" title={t("header")}>
-      <Box sx={{ px: 3, pt: 1 }}>{children}</Box>
+    <Nav navBackTo="/chat" padding="normal" title={t("header")}>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/features/settings/pages/AppearancePage/AppearancePage.nav.tsx
+++ b/services/web-ui/src/features/settings/pages/AppearancePage/AppearancePage.nav.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box } from "@mui/material";
-
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
 
@@ -15,8 +13,8 @@ export function AppearancePageNav({
   const { t } = useTranslation("settings");
 
   return (
-    <Nav navBackTo="/profile" title={t("header")}>
-      <Box sx={{ p: 3 }}>{children}</Box>
+    <Nav navBackTo="/profile" padding="normal" title={t("header")}>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/features/settings/pages/SettingsPage/SettingsPage.nav.tsx
+++ b/services/web-ui/src/features/settings/pages/SettingsPage/SettingsPage.nav.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box } from "@mui/material";
-
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
 
@@ -15,8 +13,8 @@ export function SettingsPageNav({
   const { t } = useTranslation("settings");
 
   return (
-    <Nav navBackTo="/profile" title={t("header")}>
-      <Box sx={{ p: 3 }}>{children}</Box>
+    <Nav navBackTo="/profile" padding="normal" title={t("header")}>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/features/time-series/pages/CreateTimeSeriesPage/CreateTimeSeriesPage.container.tsx
+++ b/services/web-ui/src/features/time-series/pages/CreateTimeSeriesPage/CreateTimeSeriesPage.container.tsx
@@ -1,8 +1,6 @@
 import { ReactElement } from "react";
 import { useNavigate } from "react-router";
 
-import { Box } from "@mui/material";
-
 import { useTranslation } from "src/core/i18n";
 import { useSnackbar } from "src/core/snackbar";
 
@@ -21,9 +19,7 @@ export function CreateTimeSeriesPageContainer(): ReactElement {
 
   return (
     <CreateTimeSeriesPageNav>
-      <Box sx={{ p: 2 }}>
-        <CreateTimeSeriesPageComponent onAfterSubmit={handleSubmit} />
-      </Box>
+      <CreateTimeSeriesPageComponent onAfterSubmit={handleSubmit} />
     </CreateTimeSeriesPageNav>
   );
 }

--- a/services/web-ui/src/features/time-series/pages/CreateTimeSeriesPage/CreateTimeSeriesPage.nav.tsx
+++ b/services/web-ui/src/features/time-series/pages/CreateTimeSeriesPage/CreateTimeSeriesPage.nav.tsx
@@ -13,7 +13,7 @@ export function CreateTimeSeriesPageNav({
   const { t } = useTranslation("timeseries-creation");
 
   return (
-    <Nav navBackTo="/time-series" title={t("header")}>
+    <Nav navBackTo="/time-series" padding="normal" title={t("header")}>
       {children}
     </Nav>
   );

--- a/services/web-ui/src/features/time-series/pages/TimeSeriesListPage/TimeSeriesListPage.nav.tsx
+++ b/services/web-ui/src/features/time-series/pages/TimeSeriesListPage/TimeSeriesListPage.nav.tsx
@@ -1,7 +1,6 @@
 import { ReactElement, ReactNode } from "react";
 
 import { Add } from "@mui/icons-material";
-import { Box } from "@mui/material";
 
 import { Nav } from "src/components/nav";
 import { Fab } from "src/components/ui/Fab";
@@ -17,12 +16,12 @@ export function TimeSeriesListPageNav({
   const { t } = useTranslation("timeseries");
 
   return (
-    <Nav title={t("header")}>
+    <Nav padding="normal" title={t("header")}>
       <Fab to="/time-series/create">
         <Add />
       </Fab>
 
-      <Box sx={{ p: 2, height: "100%" }}>{children}</Box>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/features/time-series/pages/TimeSeriesPage/TimeSeriesPage.nav.tsx
+++ b/services/web-ui/src/features/time-series/pages/TimeSeriesPage/TimeSeriesPage.nav.tsx
@@ -1,7 +1,5 @@
 import { ReactElement, ReactNode } from "react";
 
-import { Box } from "@mui/material";
-
 import { Nav } from "src/components/nav";
 import { useTranslation } from "src/core/i18n";
 
@@ -15,8 +13,8 @@ export function TimeSeriesPageNav({
   const { t } = useTranslation("time-series");
 
   return (
-    <Nav navBackTo="/time-series" title={t("header")}>
-      <Box sx={{ p: 2 }}> {children}</Box>
+    <Nav navBackTo="/time-series" padding="normal" title={t("header")}>
+      {children}
     </Nav>
   );
 }

--- a/services/web-ui/src/views/NotFoundView/NotFoundView.nav.tsx
+++ b/services/web-ui/src/views/NotFoundView/NotFoundView.nav.tsx
@@ -7,5 +7,5 @@ export interface NotFoundNavProps {
 }
 
 export function NotFoundNav({ children }: NotFoundNavProps): ReactElement {
-  return <Nav>{children}</Nav>;
+  return <Nav padding="none">{children}</Nav>;
 }


### PR DESCRIPTION
By moving the page padding options into the nav component, we can enforce consistent padding throughout app. We can also have different padding in the desktop and mobile navs