### PR TITLE
feat(web-ui): always use daily aggregation for time series

### DIFF
--- a/services/web-ui/src/features/time-series/components/TimeSeriesChart/TimeSeriesChart.tsx
+++ b/services/web-ui/src/features/time-series/components/TimeSeriesChart/TimeSeriesChart.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from "react";
+import { ReactElement, useMemo } from "react";
 
 import { BarChart } from "@mui/x-charts";
 
-import { TimeSeriesDetails } from "src/api";
+import { TimeSeriesDetails, TimeSeriesDetailsAggregationEnum } from "src/api";
 
 import { getAggregatedData } from "../../utils/stats.helper";
 
@@ -13,7 +13,10 @@ interface TimeSeriesChartProps {
 export function TimeSeriesChart({
   timeSeries,
 }: TimeSeriesChartProps): ReactElement {
-  const data = getAggregatedData(timeSeries);
+  const data = useMemo(
+    () => getAggregatedData(timeSeries, TimeSeriesDetailsAggregationEnum.Daily),
+    [timeSeries],
+  );
 
   return (
     <BarChart

--- a/services/web-ui/src/features/time-series/utils/stats.helper.ts
+++ b/services/web-ui/src/features/time-series/utils/stats.helper.ts
@@ -93,13 +93,16 @@ export const getChartData = (timeSeries: TimeSeriesDetails) => {
   return data;
 };
 
-export const getAggregatedData = (timeSeries: TimeSeriesDetails) => {
+export const getAggregatedData = (
+  timeSeries: TimeSeriesDetails,
+  aggregation: TimeSeriesDetailsAggregationEnum,
+) => {
   const data: Record<string, Record<string, number>> = {};
 
   for (const point of timeSeries.points) {
     const aggregatedDate = getAggregationDate(
       new Date(point.createdAt),
-      timeSeries.aggregation,
+      aggregation,
     );
 
     if (!(aggregatedDate in data)) {


### PR DESCRIPTION
The stored aggregation level on the time series is used to calculate the overview stats on the page, but might not suit so well for the chart, in this PR we hardcode it to a monthly value to see how that works.