### PR TITLE
fix(web-ui): ensure times in times series chart is local time not utc

### DIFF
--- a/services/web-ui/src/features/time-series/components/TimeSeriesChart/chart.config.test.ts
+++ b/services/web-ui/src/features/time-series/components/TimeSeriesChart/chart.config.test.ts
@@ -1,7 +1,7 @@
+import dayjs from "dayjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TimeSeriesDetailsAggregationEnum } from "src/api";
-import { parseDateInUTC } from "src/utils/time";
 
 import { CHART_CONFIGS } from "./chart.config";
 
@@ -46,8 +46,8 @@ const TESTS: Record<TimeSeriesDetailsAggregationEnum, TestProps> = {
     value: VALUE,
   },
   [TimeSeriesDetailsAggregationEnum.Hourly]: {
-    date: "2020-01-01T06:00:00Z",
-    key: "2000-01-01T06:00+00:00",
+    date: "2020-01-01T06:00:00",
+    key: "2000-01-01T06:00",
     label: "06:00",
     value: 946_706_400_000,
   },
@@ -67,7 +67,7 @@ describe("Time Series Chart Configs", () => {
     const config =
       CHART_CONFIGS[aggregation as TimeSeriesDetailsAggregationEnum];
 
-    const key = config.getGroupKey(parseDateInUTC(props.date));
+    const key = config.getGroupKey(dayjs(props.date).toDate());
     expect(key).toBe(props.key);
 
     const value = config.getValue(key);

--- a/services/web-ui/src/features/time-series/components/TimeSeriesChart/chart.config.ts
+++ b/services/web-ui/src/features/time-series/components/TimeSeriesChart/chart.config.ts
@@ -59,9 +59,9 @@ export const CHART_CONFIGS: Record<
   [TimeSeriesDetailsAggregationEnum.Hourly]: {
     scaleType: "time",
     // We use a fixed date here to coerce all hours into one day
-    getGroupKey: (date) => dayjs.utc(date).format("2000-01-01THH:00Z"),
-    getLabel: (key) => dayjs.utc(key).format("HH:00"),
-    getValue: (value) => new Date(value).valueOf(),
-    sortCompareFn: (a, b) => new Date(a).valueOf() - new Date(b).valueOf(),
+    getGroupKey: (date) => dayjs(date).format("2000-01-01THH:00"),
+    getLabel: (key) => dayjs(key).format("HH:00"),
+    getValue: (value) => dayjs(value).valueOf(),
+    sortCompareFn: (a, b) => dayjs(a).valueOf() - dayjs(b).valueOf(),
   },
 };

--- a/services/web-ui/src/test/setupTests.ts
+++ b/services/web-ui/src/test/setupTests.ts
@@ -5,6 +5,8 @@
 import "@testing-library/jest-dom";
 import { TextDecoder, TextEncoder } from "node:util";
 
+process.env.TZ = "UTC";
+
 if (!global.TextEncoder) {
   global.TextEncoder = TextEncoder;
 }

--- a/services/web-ui/vitest.config.ts
+++ b/services/web-ui/vitest.config.ts
@@ -6,9 +6,6 @@ export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      env: {
-        TZ: "UTC",
-      },
       // mui-x-grid imports a CSS file which needs this
       // as it implictly turns on CSS transforms
       pool: "vmThreads",


### PR DESCRIPTION
Times were shown in UTC time. This ensures it is instead shown in local time