### PR TITLE
fix(api): send email notification despite web push already being sent

### DIFF
--- a/services/api/src/core/notifications/domain/services/notification.service.ts
+++ b/services/api/src/core/notifications/domain/services/notification.service.ts
@@ -84,13 +84,11 @@ export class NotificationService {
       where: { id: In(profileIds) },
     });
 
-    const webPushResult = await this.notificationWebPushGateway.sendWebPush(
-      profileIds,
-      notification,
-    );
+    await this.notificationWebPushGateway.sendWebPush(profileIds, notification);
 
     const ids = profiles
-      .filter((profile) => !webPushResult[profile.id])
+      // TODO: This was reported to not be working and hence disabling it
+      // .filter((profile) => !webPushResult[profile.id])
       .map((profile) => profile.userId);
 
     await this.notifyUsers(ids, notification);


### PR DESCRIPTION
We have gotten a lot of bug reports that users do not receive any notification at all at times, perhaps because web push is not properly delivered. I do not have time to troubleshoot it and hence just disabling it