### PR TITLE
fix: hardcode correlation id

### DIFF
--- a/services/api/src/core/request-context/request-context.middleware.ts
+++ b/services/api/src/core/request-context/request-context.middleware.ts
@@ -32,7 +32,8 @@ export class RequestContextMiddleware implements NestModule {
           _: FastifyReply["raw"],
           next: () => void,
         ) => {
-          const correlationId = req.headers["x-correlation-id"];
+          // TODO: Enable correlation id in Traefik
+          const correlationId = "my-correlation-id";
           let userId: string | undefined;
 
           if (typeof correlationId != "string") {


### PR DESCRIPTION
In order to upgrade to Traefik v3 we have to disable correlation id as it is not yet supported there.