### PR TITLE
chore: bump Traefik

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -15,7 +15,6 @@ services:
       service: "traefik"
     command:
       - "--accesslog=true"
-      - "--accesslog.fields.headers.names.x-correlation-id=keep"
       - "--accesslog.format=json"
       - "--log.format=json"
 
@@ -33,10 +32,6 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=webinsecure"
       - "--certificatesresolvers.letsencrypt.acme.email=$EMAIL"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
-
-      # Adds correlation id
-      - "--tracing.jaeger.samplingparam=0"
-      - "--tracing.jaeger.tracecontextheadername=x-correlation-id"
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -4,7 +4,6 @@ services:
     container_name: "traefik"
     command:
       - "--accesslog=true"
-      - "--accesslog.fields.headers.names.x-correlation-id=keep"
       - "--api.insecure=true"
 
       - "--providers.docker=true"

--- a/docker-compose.shared.yaml
+++ b/docker-compose.shared.yaml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: "traefik:v2.11"
+    image: "traefik:v3.7.7"
     container_name: "traefik"
     command:
       - "--accesslog=true"
@@ -11,10 +11,6 @@ services:
       - "--providers.docker.exposedbydefault=false"
 
       - "--entrypoints.web.address=:80"
-
-      # Adds correlation id
-      - "--tracing.jaeger.samplingparam=0"
-      - "--tracing.jaeger.tracecontextheadername=x-correlation-id"
 
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
This bumps Traefik and removes the correlation id that is no longer supported in v3